### PR TITLE
Fix in clause detection regex

### DIFF
--- a/src/main/java/org/kostenko/example/jpa/dialect/SafeInInterceptor.java
+++ b/src/main/java/org/kostenko/example/jpa/dialect/SafeInInterceptor.java
@@ -10,7 +10,7 @@ import org.hibernate.EmptyInterceptor;
  */
 public class SafeInInterceptor extends EmptyInterceptor {
 
-    private final static Pattern pattern = Pattern.compile("[^\\s]+\\s+in\\s*\\(\\s*\\?[^\\(]*\\)", Pattern.CASE_INSENSITIVE);
+    private final static Pattern pattern = Pattern.compile("[^\\s\\(]+\\s+in\\s*\\([\\?\\,\\s]*\\)", Pattern.CASE_INSENSITIVE);
     private final static int IN_CAUSE_LIMIT = 1000;
 
     @Override


### PR DESCRIPTION
The current behaviour of SafeInInterceptor will produce faulty queries in some cases because the number of parentheses doesn't match anymore. Examples with inClauseLimit set to 2 for easier testing:

`SELECT * FROM t WHERE ( field1 IN (?, ?, ?, ?) )` -> `SELECT * FROM t WHERE ( ( field1 in (?,?) or field1 in (?,?) )`
`SELECT * FROM t WHERE (field1 IN (?, ?, ?, ?) AND field2 IN (?, ?))` -> `SELECT * FROM t WHERE ( (field1 in (?,?) or (field1 in (?,?) ) AND field2 IN (?,?))`
`SELECT * FROM t WHERE ( field1 IN (?, ?, ?, ?) AND (field2 IN (?,?,?,?)))` -> `SELECT * FROM t WHERE ( ( field1 in (?,?) or field1 in (?,?) ) AND ( (field2 in (?,?) or (field2 in (?,?) )`

Changing the regex to `[^\s\(]+\s+in\s*\([\?\,\s]*\)` to only match the field name and the innermost parentheses of the in clause fixes these issues.